### PR TITLE
Task/tao 4692 migrate to libsass

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -23,9 +23,9 @@ return array(
     'label' => 'xmlEditQtiDebugger',
     'description' => 'xml editing and debugging tools',
     'license' => 'GPL-2.0',
-    'version' => '1.0.0',
-	'author' => 'Open Assessment Technologies SA',
-	'requires' => array(
+    'version' => '1.0.1',
+    'author' => 'Open Assessment Technologies SA',
+    'requires' => array(
         'xmlEdit' => '>=1.1.0',
         'taoQtiItem' => '>=2.27.0'
     ),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -38,12 +38,12 @@ class Updater extends common_ext_ExtensionUpdater
     {
         $this->setVersion($initialVersion);
 
-        if($this->isVersion('0.1.0')){
+        if ($this->isVersion('0.1.0')) {
             $registry = QtiCreatorClientConfigRegistry::getRegistry();
             $registry->registerPlugin('xmlResponseProcessing', 'xmlEditQtiDebugger/qtiCreator/plugins/menu/xmlEditor', 'menu');
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '1.0.0');
+        $this->skip('0.2.0', '1.0.1');
     }
 }

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -8,9 +8,7 @@ module.exports = function(grunt) {
 
     //override load path
     sass.xmleditqtidebugger = {
-        options : {
-            loadPath : ['../scss/', root + 'scss/inc']
-        },
+        options : {},
         files : {}
     };
 

--- a/views/css/editor.css
+++ b/views/css/editor.css
@@ -1,2 +1,3 @@
 .tao-xml-editor.qti-creator-source{position:absolute;height:calc(100vh - 135px);z-index:301;left:0;top:101px;width:100%;overflow:hidden}
+
 /*# sourceMappingURL=editor.css.map */

--- a/views/css/editor.css.map
+++ b/views/css/editor.css.map
@@ -1,7 +1,14 @@
 {
-"version": 3,
-"mappings": "AAGA,kCAAkC,CAC9B,QAAQ,CAAE,QAAQ,CAClB,MAAM,CAAG,mBAAmB,CAC5B,OAAO,CAAE,GAAG,CACZ,IAAI,CAAE,CAAC,CACP,GAAG,CAAE,KAAK,CACV,KAAK,CAAC,IAAI,CACV,QAAQ,CAAE,MAAM",
-"sources": ["../scss/editor.scss"],
-"names": [],
-"file": "editor.css"
+	"version": 3,
+	"file": "editor.css",
+	"sources": [
+		"../scss/editor.scss",
+		"../../../tao/views/scss/inc/_bootstrap.scss",
+		"../../../tao/views/scss/inc/_variables.scss",
+		"../../../tao/views/scss/inc/_functions.scss",
+		"../../../tao/views/scss/inc/_colors.scss",
+		"../../../tao/views/scss/inc/fonts/_tao-icon-vars.scss"
+	],
+	"names": [],
+	"mappings": "AAGA,AAAA,eAAe,AAAA,mBAAmB,AAAA,CAC9B,QAAQ,CAAE,QAAQ,CAClB,MAAM,CAAG,mBAAmB,CAC5B,OAAO,CAAE,GAAG,CACZ,IAAI,CAAE,CAAC,CACP,GAAG,CAAE,KAAK,CACV,KAAK,CAAC,IAAI,CACV,QAAQ,CAAE,MAAM,CACnB"
 }


### PR DESCRIPTION
Task - Tao
Jira: https://oat-sa.atlassian.net/browse/TAO-4692

Companion (but does not require):
- https://github.com/oat-sa/tao-core/pull/1410

This pr is meant to accompany the switch to libsass. Because the grunt sass script does not require a loadPath/includeFiles sass option, it is compatible with both ruby sass and libsass.